### PR TITLE
NEVISACCESSAPP-7321: upgrade deprecated node20 GitHub Actions to node24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Ensure correct Xcode version is installed.
       - name: Setup Xcode

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,4 @@ jobs:
 
       # Build & Distribute
       - name: Run Fastlane
-        uses: maierj/fastlane-action@v3.1.0
-        with:
-          lane: 'main'
+        run: bundle exec fastlane main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,4 @@ jobs:
 
       # Build & Distribute
       - name: Run Fastlane
-        uses: maierj/fastlane-action@v3.1.0
-        with:
-          lane: 'pr'
+        run: bundle exec fastlane pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Ensure correct Xcode version is installed.
       - name: Setup Xcode


### PR DESCRIPTION
Upgrades actions from node20 to node24 runtime to resolve
deprecation warnings after Node.js 20 reached EOL (Apr 2026).